### PR TITLE
feat(atom-with-hash): allow optional `setHash`

### DIFF
--- a/src/atomWithHash.ts
+++ b/src/atomWithHash.ts
@@ -45,6 +45,9 @@ export function atomWithHash<Value>(
         window.removeEventListener('hashchange', callback);
       };
     });
+  if (options?.replaceState) {
+    console.warn('[DEPRECATED] Use setHash=replaceState instead');
+  }
   const setHashOption = options?.setHash;
   let setHash = (searchParams: string) => {
     window.location.hash = searchParams;

--- a/src/atomWithHash.ts
+++ b/src/atomWithHash.ts
@@ -21,6 +21,7 @@ export function atomWithHash<Value>(
     delayInit?: boolean;
     replaceState?: boolean;
     subscribe?: (callback: () => void) => () => void;
+    setHash?: (searchParams: URLSearchParams) => void;
   },
 ): WritableAtom<Value, SetStateActionWithReset<Value>> {
   const serialize = options?.serialize || JSON.stringify;
@@ -41,19 +42,21 @@ export function atomWithHash<Value>(
         window.removeEventListener('hashchange', callback);
       };
     });
-  const setHash = (searchParams: URLSearchParams) => {
-    if (options?.replaceState) {
-      window.history.replaceState(
-        null,
-        '',
-        `${window.location.pathname}${
-          window.location.search
-        }#${searchParams.toString()}`,
-      );
-    } else {
-      window.location.hash = searchParams.toString();
-    }
-  };
+  const setHash =
+    options?.setHash ||
+    ((searchParams) => {
+      if (options?.replaceState) {
+        window.history.replaceState(
+          null,
+          '',
+          `${window.location.pathname}${
+            window.location.search
+          }#${searchParams.toString()}`,
+        );
+      } else {
+        window.location.hash = searchParams.toString();
+      }
+    });
   const hashStorage = {
     getItem: (k: string) => {
       if (typeof window.location === 'undefined') {

--- a/src/atomWithHash.ts
+++ b/src/atomWithHash.ts
@@ -19,9 +19,12 @@ export function atomWithHash<Value>(
     serialize?: (val: Value) => string;
     deserialize?: (str: string | null) => Value | typeof NO_STORAGE_VALUE;
     delayInit?: boolean;
+    /**
+     * @deprecated Use {@link options.setHash} with 'replaceState' instead
+     */
     replaceState?: boolean;
     subscribe?: (callback: () => void) => () => void;
-    setHash?: (searchParams: URLSearchParams) => void;
+    setHash?: 'default' | 'replaceState' | ((searchParams: string) => void);
   },
 ): WritableAtom<Value, SetStateActionWithReset<Value>> {
   const serialize = options?.serialize || JSON.stringify;
@@ -42,21 +45,22 @@ export function atomWithHash<Value>(
         window.removeEventListener('hashchange', callback);
       };
     });
-  const setHash =
-    options?.setHash ||
-    ((searchParams) => {
-      if (options?.replaceState) {
-        window.history.replaceState(
-          null,
-          '',
-          `${window.location.pathname}${
-            window.location.search
-          }#${searchParams.toString()}`,
-        );
-      } else {
-        window.location.hash = searchParams.toString();
-      }
-    });
+  const setHashOption = options?.setHash;
+  let setHash = (searchParams: string) => {
+    window.location.hash = searchParams;
+  };
+  if (setHashOption === 'replaceState' || options?.replaceState) {
+    setHash = (searchParams) => {
+      window.history.replaceState(
+        null,
+        '',
+        `${window.location.pathname}${window.location.search}#${searchParams}`,
+      );
+    };
+  }
+  if (typeof setHashOption === 'function') {
+    setHash = setHashOption;
+  }
   const hashStorage = {
     getItem: (k: string) => {
       if (typeof window.location === 'undefined') {
@@ -69,12 +73,12 @@ export function atomWithHash<Value>(
     setItem: (k: string, newValue: Value) => {
       const searchParams = new URLSearchParams(window.location.hash.slice(1));
       searchParams.set(k, serialize(newValue));
-      setHash(searchParams);
+      setHash(searchParams.toString());
     },
     removeItem: (k: string) => {
       const searchParams = new URLSearchParams(window.location.hash.slice(1));
       searchParams.delete(k);
-      setHash(searchParams);
+      setHash(searchParams.toString());
     },
     ...(options?.delayInit && { delayInit: true }),
     subscribe: (k: string, setValue: (v: Value) => void) => {


### PR DESCRIPTION
## Problem

Changing the hash using window.location can be in conflict with the next router. To reproduce this issue within a next app:

1. Use `atomWithHash` somewhere in the app using `{ replaceState: true }`
2. Navigate to the page with `atomWithHash` (using next router)
3. Trigger a change that will invoke setting the hash via `atomWithHash`
3. Navigate in browser going back in history
4. Try and navigate in browser going forward
5. Will behave unexpectedly changing the URL, but not changing the page

This might also be unexpected behavior from the perspective of the next router. I'm not entirely sure. But I can imagine other routers possibly also having problems with this.

## Solution

Changing the `setHash` function fixed this issue so my proposed solution using this commit's changes are:

```ts
import Router from 'next/router'
import { atomWithHash } from 'jotai-location'

atomWithHash('key', 'default', {
  subscribe: (callback) => {
    Router.events.on('hashChangeComplete', callback)
    return () => {
      Router.events.off('hashChangeComplete', callback)
    }
  },
  setHash: (searchParams) => {
    Router.replace({ hash: searchParams.toString() })
  },
})
```

## What I don't like about these changes

I'm not entirely happy with this API as using `replaceState` with `setHash` makes `replaceState` unused. But for now I wanted to make minimal changes.

what do you think?